### PR TITLE
Add scale utility and broaden test coverage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,5 @@ export const version = "0.1.0";
  * @returns empty string for now
  */
 import { renderSchedule } from "./renderer/index.js";
-export { renderSchedule };
+import { inferScale } from "./renderer/scale.js";
+export { renderSchedule, inferScale };

--- a/src/renderer/scale.ts
+++ b/src/renderer/scale.ts
@@ -1,0 +1,13 @@
+import type { Scale } from "./layout.js";
+
+/**
+ * Infer a suitable time scale based on the provided duration in milliseconds.
+ * Durations up to 1s use the "ms" scale, up to 1 minute use "second",
+ * up to 1 hour use "minute", otherwise "hour".
+ */
+export function inferScale(durationMs: number): Scale {
+  if (durationMs <= 1000) return "ms";
+  if (durationMs <= 60 * 1000) return "second";
+  if (durationMs <= 60 * 60 * 1000) return "minute";
+  return "hour";
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -23,6 +23,68 @@ describe("CLI integration", () => {
     expect(out).toContain("█");
     rmSync(tmp, { recursive: true, force: true });
   });
+
+  it("passes scale option to renderer", () => {
+    const tmp = mkdtempSync(join(os.tmpdir(), "ganttscape-"));
+    const file = join(tmp, "sched.json");
+    writeFileSync(
+      file,
+      JSON.stringify([
+        {
+          label: "A",
+          start: "2024-05-01T00:00:00.000Z",
+          end: "2024-05-01T00:00:00.002Z",
+        },
+      ]),
+      "utf-8",
+    );
+    const cliPath = join(process.cwd(), "dist", "cli.js");
+    const result = execaSync("node", [cliPath, file, "--scale", "ms"]);
+    expect(result.stdout).toContain(".000");
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("passes width option to renderer", () => {
+    const tmp = mkdtempSync(join(os.tmpdir(), "ganttscape-"));
+    const file = join(tmp, "sched.json");
+    writeFileSync(
+      file,
+      JSON.stringify([
+        {
+          label: "A",
+          start: "2024-05-01T00:00:00Z",
+          end: "2024-05-01T00:00:02Z",
+        },
+      ]),
+      "utf-8",
+    );
+    const cliPath = join(process.cwd(), "dist", "cli.js");
+    const result = execaSync("node", [cliPath, file, "--width", "1", "--scale", "second"]);
+    const header = result.stdout.split("\n")[0];
+    const cols = header.trim().split(/\s+/);
+    expect(cols).toHaveLength(1);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("respects no-color flag", () => {
+    const tmp = mkdtempSync(join(os.tmpdir(), "ganttscape-"));
+    const file = join(tmp, "sched.json");
+    writeFileSync(
+      file,
+      JSON.stringify([
+        {
+          label: "A",
+          start: "2024-05-01T00:00:00Z",
+          end: "2024-05-01T00:00:02Z",
+        },
+      ]),
+      "utf-8",
+    );
+    const cliPath = join(process.cwd(), "dist", "cli.js");
+    const result = execaSync("node", [cliPath, file, "--no-color"]);
+    expect(/\u001b\[/.test(result.stdout)).toBe(false);
+    rmSync(tmp, { recursive: true, force: true });
+  });
   it("exits with error when no arguments", () => {
     const cliPath = join(process.cwd(), "dist", "cli.js");
     const result = execaSync("node", [cliPath], { reject: false });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -12,3 +12,29 @@ describe("core API", () => {
     expect(typeof result).toBe("string");
   });
 });
+
+describe("renderSchedule options", () => {
+  const schedule: Schedule = {
+    tasks: [
+      {
+        label: "A",
+        start: new Date("2024-05-01T00:00:00Z"),
+        end: new Date("2024-05-01T00:00:02Z"),
+      },
+    ],
+  };
+
+  it("honours width option", () => {
+    const output = renderSchedule(schedule, { width: 1, scale: "second" });
+    const header = output.split("\n")[0];
+    const cols = header.trim().split(/\s+/);
+    expect(cols).toHaveLength(1);
+  });
+
+  it("honours scale option", () => {
+    const outSecond = renderSchedule(schedule, { scale: "second" });
+    const outMinute = renderSchedule(schedule, { scale: "minute" });
+    expect(outSecond.split("\n")[0]).toContain("00:00:01");
+    expect(outMinute.split("\n")[0]).not.toContain("00:00:01");
+  });
+});

--- a/tests/scale.test.ts
+++ b/tests/scale.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { inferScale } from "../src/renderer/scale.js";
+
+describe("inferScale", () => {
+  it("returns ms for durations up to 1s", () => {
+    expect(inferScale(1)).toBe("ms");
+    expect(inferScale(1000)).toBe("ms");
+  });
+
+  it("returns second for durations up to 1 minute", () => {
+    expect(inferScale(1001)).toBe("second");
+    expect(inferScale(60 * 1000)).toBe("second");
+  });
+
+  it("returns minute for durations up to 1 hour", () => {
+    expect(inferScale(60 * 1000 + 1)).toBe("minute");
+    expect(inferScale(60 * 60 * 1000)).toBe("minute");
+  });
+
+  it("returns hour for longer durations", () => {
+    expect(inferScale(60 * 60 * 1000 + 1)).toBe("hour");
+  });
+});


### PR DESCRIPTION
## Summary
- expose new `inferScale` helper for choosing ms/second/minute/hour
- test CLI options for scale, width and no-color
- test SDK options on `renderSchedule`
- add new unit tests for `inferScale` boundaries

## Testing
- `yarn build`
- `npx vitest run`
