### PR TITLE
Improve grid depth and nested rendering

### DIFF
--- a/src/renderer/layout.ts
+++ b/src/renderer/layout.ts
@@ -29,12 +29,29 @@ export function generateGrid(tasks: Task[], scale: Scale = "second"): Grid {
   let maxDate = tasks[0].end;
   const labelLengths: number[] = [];
   const taskMap: Record<string, Task> = {};
+
+  // Build lookup map first so we can follow parent chains
+  tasks.forEach((t) => {
+    taskMap[t.label] = t;
+  });
+
+  // Helper to compute depth by traversing the parent chain
+  function getDepth(task: Task): number {
+    let depth = 0;
+    let current = task.parent;
+    while (current && taskMap[current]) {
+      depth += 1;
+      current = taskMap[current].parent;
+    }
+    return depth;
+  }
+
   tasks.forEach((t) => {
     if (t.start < minDate) minDate = t.start;
     if (t.end > maxDate) maxDate = t.end;
+    const depth = getDepth(t);
     // length plus indentation for nested tasks
-    labelLengths.push(t.label.length + (t.parent ? 2 : 0));
-    taskMap[t.label] = t;
+    labelLengths.push(t.label.length + depth * 2);
   });
   // Build time array according to scale
   const stepMs =
@@ -51,7 +68,7 @@ export function generateGrid(tasks: Task[], scale: Scale = "second"): Grid {
   }
   // Compute rows
   const rows = tasks.map((t) => {
-    const depth = t.parent && taskMap[t.parent] ? 1 : 0;
+    const depth = getDepth(t);
     const cells = dates.map((d) => d >= t.start && d <= t.end);
     return { label: t.label, depth, cells, tags: t.tags };
   });

--- a/tests/__snapshots__/renderer.test.ts.snap
+++ b/tests/__snapshots__/renderer.test.ts.snap
@@ -1,5 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`renderSchedule > renders nested tasks correctly 1`] = `
+"        00:00:00 00:00:01 00:00:02 00:00:03
+A       ████
+  B     ░███
+    C   ░░██
+      D ░░░█"
+`;
+
 exports[`renderSchedule > renders simple schedule snapshot 1`] = `
 "         00:00:00 00:00:01 00:00:02 00:00:03
 Task A   ███░

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -24,4 +24,30 @@ describe("layout utils", () => {
     expect(grid.rows[0].cells).toEqual([true, true]);
     expect(grid.labelWidth).toBe(1);
   });
+
+  it("generateGrid computes depth recursively", () => {
+    const tasks: Task[] = [
+      {
+        label: "A",
+        start: new Date("2024-05-01T00:00:00Z"),
+        end: new Date("2024-05-01T00:00:03Z"),
+      },
+      {
+        label: "B",
+        start: new Date("2024-05-01T00:00:01Z"),
+        end: new Date("2024-05-01T00:00:03Z"),
+        parent: "A",
+      },
+      {
+        label: "C",
+        start: new Date("2024-05-01T00:00:02Z"),
+        end: new Date("2024-05-01T00:00:03Z"),
+        parent: "B",
+      },
+    ];
+    const grid = generateGrid(tasks, "second");
+    expect(grid.rows.map((r) => r.depth)).toEqual([0, 1, 2]);
+    // label width should include indentation for deepest level
+    expect(grid.labelWidth).toBe(5);
+  });
 });

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -9,4 +9,36 @@ describe("renderSchedule", () => {
     const output = renderSchedule(schedule, { scale: "second" });
     expect(output).toMatchSnapshot();
   });
+
+  it("renders nested tasks correctly", () => {
+    const schedule = {
+      tasks: [
+        {
+          label: "A",
+          start: new Date("2024-05-01T00:00:00Z"),
+          end: new Date("2024-05-01T00:00:03Z"),
+        },
+        {
+          label: "B",
+          start: new Date("2024-05-01T00:00:01Z"),
+          end: new Date("2024-05-01T00:00:03Z"),
+          parent: "A",
+        },
+        {
+          label: "C",
+          start: new Date("2024-05-01T00:00:02Z"),
+          end: new Date("2024-05-01T00:00:03Z"),
+          parent: "B",
+        },
+        {
+          label: "D",
+          start: new Date("2024-05-01T00:00:03Z"),
+          end: new Date("2024-05-01T00:00:03Z"),
+          parent: "C",
+        },
+      ],
+    };
+    const output = renderSchedule(schedule, { scale: "second" });
+    expect(output).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary
- compute task depth by following the parent chain
- include indentation in label width calculation
- test grid generation for deep nesting
- snapshot test for rendering nested tasks

## Testing
- `npm run build`
- `npm test`