### PR TITLE
Add auto scale detection to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ ganttscape [options] <file>
 
 Options:
 -V, --version output the version number
---scale <ms|second|minute|hour> Time scale (default: second)
+--scale <auto|ms|second|minute|hour> Time scale (default: auto)
 -w, --width <n> Truncate timeline width to n time slots
 --no-color Disable ANSI colors
 -h, --help display help for command
@@ -52,7 +52,7 @@ Given `examples/parallel-analysis.yaml`:
   tags: [result]
 ```
 
-Running (default second scale):
+Running (default auto scale):
 
 ```bash
 $ ganttscape examples/parallel-analysis.yaml

--- a/design-doc.md
+++ b/design-doc.md
@@ -90,7 +90,7 @@ Build an open‑source TypeScript command‑line tool that renders project timel
 
 ### 8. Rendering Specification
 
-- **Time axis granularity:** second columns by default (`--scale ms|minute|hour`).
+ - **Time axis granularity:** automatic scale detection by default (`--scale auto|ms|minute|hour`).
 - **Characters:** full block `█` for duration, light shade `░` for incomplete; fallback to `#` when Unicode not supported.
 - **Colours:** auto‑assign distinct hues per tag (max 8) or use monochrome.
 - **Layout rules**
@@ -132,7 +132,7 @@ Build an open‑source TypeScript command‑line tool that renders project timel
 
 | Version | Features                                                         |
 | ------- | ---------------------------------------------------------------- |
-| v0.1.0  | YAML+JSON input, second scale, colours off flag, ESM+CJS bundles. |
+| v0.1.0  | YAML+JSON input, auto scale detection, colours off flag, ESM+CJS bundles. |
 | v0.2.0  | Weekly/month scale, CSV input, tag colour configuration.         |
 | v0.3.0  | Windows ANSI support, interactive scroll mode (Ink).             |
 | v1.0.0  | Mermaid export, PNG/SVG generation, plugin API, Windows GA.      |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { parseSchedule, renderSchedule, version } from "./index.js";
+import {
+  parseSchedule,
+  renderSchedule,
+  version,
+  inferScheduleScale,
+} from "./index.js";
 
 const program = new Command();
 
@@ -13,8 +18,8 @@ program
   .argument("<file>", "Path to schedule file (YAML or JSON)")
   .option(
     "--scale <scale>",
-    "Time scale: ms | second | minute | hour",
-    "second",
+    "Time scale: auto | ms | second | minute | hour",
+    "auto",
   )
   .option(
     "-w, --width <number>",
@@ -25,7 +30,7 @@ program
   .option("--no-color", "Disable ANSI colors")
   .action((file, options) => {
     const { scale, width, color } = options;
-    if (!["ms", "second", "minute", "hour"].includes(scale)) {
+    if (!["ms", "second", "minute", "hour", "auto"].includes(scale)) {
       console.error(`Unsupported scale: ${scale}`);
       process.exit(1);
     }
@@ -47,9 +52,11 @@ program
       console.error("Error parsing schedule:", err instanceof Error ? err.message : err);
       process.exit(1);
     }
+    const finalScale =
+      scale === "auto" ? inferScheduleScale(schedule.tasks) : scale;
     let output;
     try {
-      output = renderSchedule(schedule, { width, scale });
+      output = renderSchedule(schedule, { width, scale: finalScale });
     } catch (err) {
       console.error("Error rendering schedule:", err instanceof Error ? err.message : err);
       process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@ export const version = "0.1.0";
  * @returns empty string for now
  */
 import { renderSchedule } from "./renderer/index.js";
-import { inferScale } from "./renderer/scale.js";
-export { renderSchedule, inferScale };
+import { inferScale, inferScheduleScale } from "./renderer/scale.js";
+export { renderSchedule, inferScale, inferScheduleScale };

--- a/src/renderer/layout.ts
+++ b/src/renderer/layout.ts
@@ -52,7 +52,7 @@ export function generateGrid(tasks: Task[], scale: Scale = "second"): Grid {
     if (t.end > maxDate) maxDate = t.end;
     const depth = getDepth(t);
     // length plus indentation for nested tasks
-    labelLengths.push(stringWidth(t.label) + (t.parent ? 2 : 0));
+    labelLengths.push(stringWidth(t.label) + depth * 2);
     taskMap[t.label] = t;
   });
   // Build time array according to scale

--- a/src/renderer/scale.ts
+++ b/src/renderer/scale.ts
@@ -1,4 +1,5 @@
 import type { Scale } from "./layout.js";
+import type { Task } from "../core/types.js";
 
 /**
  * Infer a suitable time scale based on the provided duration in milliseconds.
@@ -10,4 +11,21 @@ export function inferScale(durationMs: number): Scale {
   if (durationMs <= 60 * 1000) return "second";
   if (durationMs <= 60 * 60 * 1000) return "minute";
   return "hour";
+}
+
+/**
+ * Infer a suitable scale for a full schedule by looking at the earliest
+ * start and latest end times of all tasks.
+ */
+export function inferScheduleScale(tasks: Task[]): Scale {
+  if (tasks.length === 0) {
+    return "second";
+  }
+  let min = tasks[0].start.getTime();
+  let max = tasks[0].end.getTime();
+  for (const t of tasks) {
+    if (t.start.getTime() < min) min = t.start.getTime();
+    if (t.end.getTime() > max) max = t.end.getTime();
+  }
+  return inferScale(max - min);
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -44,6 +44,26 @@ describe("CLI integration", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
+  it("accepts auto scale option", () => {
+    const tmp = mkdtempSync(join(os.tmpdir(), "ganttscape-"));
+    const file = join(tmp, "sched.json");
+    writeFileSync(
+      file,
+      JSON.stringify([
+        {
+          label: "A",
+          start: "2024-05-01T00:00:00Z",
+          end: "2024-05-03T00:00:00Z",
+        },
+      ]),
+      "utf-8",
+    );
+    const cliPath = join(process.cwd(), "dist", "cli.js");
+    const result = execaSync("node", [cliPath, file, "--scale", "auto"]);
+    expect(result.stdout).toContain("A");
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
   it("passes width option to renderer", () => {
     const tmp = mkdtempSync(join(os.tmpdir(), "ganttscape-"));
     const file = join(tmp, "sched.json");

--- a/tests/scale.test.ts
+++ b/tests/scale.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { inferScale } from "../src/renderer/scale.js";
+import { inferScale, inferScheduleScale } from "../src/renderer/scale.js";
+import type { Task } from "../src/core/types.js";
 
 describe("inferScale", () => {
   it("returns ms for durations up to 1s", () => {
@@ -19,5 +20,22 @@ describe("inferScale", () => {
 
   it("returns hour for longer durations", () => {
     expect(inferScale(60 * 60 * 1000 + 1)).toBe("hour");
+  });
+});
+
+describe("inferScheduleScale", () => {
+  it("handles empty task list", () => {
+    expect(inferScheduleScale([])).toBe("second");
+  });
+
+  it("infers hour scale for multi-day schedule", () => {
+    const tasks: Task[] = [
+      {
+        label: "A",
+        start: new Date("2021-01-01"),
+        end: new Date("2021-01-03"),
+      },
+    ];
+    expect(inferScheduleScale(tasks)).toBe("hour");
   });
 });


### PR DESCRIPTION
## Summary
- support `auto` scale in CLI and make it the default
- infer schedule scale automatically
- document the new default
- fix layout label width calculation
- update tests for auto scale

## Testing
- `yarn lint`
- `yarn build`
- `yarn test`